### PR TITLE
Replace abandoned `warrant` with `pycognito` (fixes install on Python 3.12+)

### DIFF
--- a/custom_components/waterguru/manifest.json
+++ b/custom_components/waterguru/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": [],
   "documentation": "https://github.com/dwradcliffe/home-assistant-waterguru",
   "iot_class": "cloud_polling",
-  "requirements": ["requests_aws4auth", "boto3", "warrant"],
+  "requirements": ["requests_aws4auth", "boto3", "pycognito"],
   "version": "0.0.1"
 }

--- a/custom_components/waterguru/waterguru.py
+++ b/custom_components/waterguru/waterguru.py
@@ -5,8 +5,8 @@ import boto3
 import botocore
 import requests
 from requests_aws4auth import AWS4Auth
-from warrant import Cognito
-from warrant.aws_srp import AWSSRP
+from pycognito import Cognito
+from pycognito.aws_srp import AWSSRP
 
 from .waterguru_device import WaterGuruDevice
 


### PR DESCRIPTION
## Problem

`warrant` (last released 2018) no longer installs on modern Python. It depends on an old `pycryptodome` that has no wheels for recent interpreters, so pip falls back to a source build — which fails in environments without a C toolchain, including the **Home Assistant container**. The failure is hard on **Python 3.13/3.14** (HA 2024.11+ / 2026.x), making the integration impossible to set up:

```
error: command 'gcc' failed: No such file or directory
ERROR: Failed building wheel for pycryptodome
ModuleNotFoundError: No module named 'warrant'
```

## Fix

Swap `warrant` → [`pycognito`](https://github.com/pvizeli/pycognito), its maintained successor. `pycognito` exposes the same API this integration already uses —

- `from pycognito.aws_srp import AWSSRP` — `AWSSRP(username, password, pool_id, client_id, client=...)`, `.authenticate_user()` returning the same `AuthenticationResult` dict
- `from pycognito import Cognito` — `Cognito(pool_id, client_id, id_token=, refresh_token=, access_token=)`, `.get_user()` with `._metadata['username']`

— so the change is a drop-in: two import lines in `waterguru.py` plus the `manifest.json` requirement. `pycognito` ships wheels and installs cleanly on Python 3.14.

## Verification

Tested end-to-end on **Home Assistant 2026.4.1 / Python 3.14**: dependency installs without a compiler, Cognito SRP auth succeeds, and all sensors populate against the live WaterGuru API (pH, free chlorine, water temp, alkalinity, salt, cassette life, battery, status, etc.) across multiple SENSE devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)