### PR TITLE
Migrate to pycognito for auth and fix 10ppm Free Chlorine cap

### DIFF
--- a/custom_components/waterguru/manifest.json
+++ b/custom_components/waterguru/manifest.json
@@ -6,6 +6,6 @@
   "dependencies": [],
   "documentation": "https://github.com/dwradcliffe/home-assistant-waterguru",
   "iot_class": "cloud_polling",
-  "requirements": ["requests_aws4auth", "boto3", "warrant"],
+  "requirements": ["requests_aws4auth", "boto3", "pycognito"],
   "version": "0.0.1"
 }

--- a/custom_components/waterguru/waterguru.py
+++ b/custom_components/waterguru/waterguru.py
@@ -67,7 +67,7 @@ class WaterGuru:
 
         method = 'POST'
         headers = {'User-Agent': 'aws-sdk-iOS/2.24.3 iOS/14.7.1 en_US invoker', 'Content-Type': 'application/x-amz-json-1.0'}
-        body = {"userId":userId, "clientType":"WEB_APP", "clientVersion":"0.2.3"}
+        body = {"userId":userId, "clientType":"WEB_APP", "clientVersion":"0.2.3", "clip": False}
         service = 'lambda'
         url = 'https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/prod-getDashboardView/invocations'
         region = 'us-west-2'

--- a/custom_components/waterguru/waterguru.py
+++ b/custom_components/waterguru/waterguru.py
@@ -5,8 +5,8 @@ import boto3
 import botocore
 import requests
 from requests_aws4auth import AWS4Auth
-from warrant import Cognito
-from warrant.aws_srp import AWSSRP
+from pycognito import Cognito
+from pycognito.aws_srp import AWSSRP
 
 from .waterguru_device import WaterGuruDevice
 


### PR DESCRIPTION
This PR bundles two critical fixes:

1. Replaces the deprecated `warrant` library with `pycognito` to restore authentication functionality (incorporating changes originally drafted by @jma24).
2. Appends `"clip": False` to the API request payload. This bypasses the legacy backend behavior that artificially caps Free Chlorine readings at 10.0ppm. 

Resolves Issue #15