### PR TITLE
Feature reset cassette

### DIFF
--- a/custom_components/waterguru/__init__.py
+++ b/custom_components/waterguru/__init__.py
@@ -16,7 +16,11 @@ from .waterguru import WaterGuru, WaterGuruApiError, WaterGuruDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BUTTON,
+    Platform.SWITCH,
+]
 INTERVAL = timedelta(minutes=30) # water temperature is updated every 30 minutes
 
 WaterGuruDataCoordinatorType = DataUpdateCoordinator[dict[str, WaterGuruDevice]]

--- a/custom_components/waterguru/__init__.py
+++ b/custom_components/waterguru/__init__.py
@@ -51,6 +51,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_method=_update_method,
         update_interval=INTERVAL,
     )
+    
+    # Expose the API client to other platforms
+    coordinator.api = waterguru
+
     await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/custom_components/waterguru/__init__.py
+++ b/custom_components/waterguru/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import DOMAIN, CASSETTE_ISSUE_PREFIX
 from .waterguru import WaterGuru, WaterGuruApiError, WaterGuruDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,6 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 INTERVAL = timedelta(minutes=30) # water temperature is updated every 30 minutes
-CASSETTE_ISSUE_PREFIX = "cassette_empty_"
 
 # device IDs we've synced cassette repairs for, keyed by config entry id
 _cassette_known_devices: dict[str, set[str]] = {}
@@ -56,7 +55,7 @@ def _async_check_cassette_repairs(
                 hass,
                 DOMAIN,
                 issue_id,
-                is_fixable=False,
+                is_fixable=True,
                 severity=ir.IssueSeverity.WARNING,
                 translation_key="cassette_empty",
                 translation_placeholders={"name": device.name},

--- a/custom_components/waterguru/__init__.py
+++ b/custom_components/waterguru/__init__.py
@@ -47,8 +47,11 @@ def _async_check_cassette_repairs(
 
     for device_id, device in devices.items():
         issue_id = f"{CASSETTE_ISSUE_PREFIX}{device_id}"
-        days = device.sensors.get("cassette_days_remaining")
-        if days == 0:
+        
+        # Evaluate percentage instead of conditional days text
+        pct_remaining = device.sensors.get("cassette")
+        
+        if pct_remaining == 0:
             ir.async_create_issue(
                 hass,
                 DOMAIN,
@@ -60,7 +63,6 @@ def _async_check_cassette_repairs(
             )
         else:
             ir.async_delete_issue(hass, DOMAIN, issue_id)
-
 
 def _async_clear_cassette_repairs(
     hass: HomeAssistant, device_ids: set[str]

--- a/custom_components/waterguru/button.py
+++ b/custom_components/waterguru/button.py
@@ -35,7 +35,8 @@ class WaterGuruResetButton(ButtonEntity):
         if not device_data:
             raise HomeAssistantError("Device data not available.")
             
-        days_remaining = device_data.sensors.get("cassette_days_remaining", 0)
+        pct_remaining = device_data.sensors.get("cassette", 0)
+        days_remaining = device_data.sensors.get("cassette_days_remaining")
 
         registry = er.async_get(self.hass)
         switch_unique_id = f"{self.device.device_id}_cassette_override"
@@ -44,11 +45,14 @@ class WaterGuruResetButton(ButtonEntity):
         override_state = self.hass.states.get(override_switch_id) if override_switch_id else None
         is_overridden = override_state is not None and override_state.state == STATE_ON
 
-        if days_remaining > 0 and not is_overridden:
-            raise HomeAssistantError(
-                f"Cannot replace: {days_remaining} days remaining. "
-                "Enable the 'Temporarily Allow Early Cassette Replacement' switch to bypass."
-            )
+        if pct_remaining > 0 and not is_overridden:
+            if days_remaining is not None:
+                error_msg = f"Cannot replace: {days_remaining} days remaining."
+            else:
+                error_msg = f"Cannot replace: {pct_remaining}% remaining."
+                
+            error_msg += " Enable the 'Temporarily Allow Early Cassette Replacement' switch to bypass."
+            raise HomeAssistantError(error_msg)
 
         api = self.coordinator.api
         await self.hass.async_add_executor_job(api.reset_cassette, self.device.device_id)

--- a/custom_components/waterguru/button.py
+++ b/custom_components/waterguru/button.py
@@ -65,7 +65,7 @@ class WaterGuruResetButton(ButtonEntity):
 
         # 2. Execute the reset command (incurs network latency)
         api = self.coordinator.api
-        await self.hass.async_add_executor_job(api.reset_cassette, self.device.device_id)
+        await self.hass.async_add_executor_job(api.reset_cassette, device_data.serial_number)
 
         # 3. Refresh the sensor data (incurs network latency)
         await self.coordinator.async_request_refresh()

--- a/custom_components/waterguru/button.py
+++ b/custom_components/waterguru/button.py
@@ -54,11 +54,7 @@ class WaterGuruResetButton(ButtonEntity):
             error_msg += " Enable the 'Temporarily Allow Early Cassette Replacement' switch to bypass."
             raise HomeAssistantError(error_msg)
 
-        api = self.coordinator.api
-        await self.hass.async_add_executor_job(api.reset_cassette, self.device.device_id)
-
-        await self.coordinator.async_request_refresh()
-
+        # 1. Turn off the override switch immediately for UI responsiveness
         if is_overridden and override_switch_id:
             await self.hass.services.async_call(
                 "switch",
@@ -66,3 +62,10 @@ class WaterGuruResetButton(ButtonEntity):
                 {"entity_id": override_switch_id},
                 blocking=False
             )
+
+        # 2. Execute the reset command (incurs network latency)
+        api = self.coordinator.api
+        await self.hass.async_add_executor_job(api.reset_cassette, self.device.device_id)
+
+        # 3. Refresh the sensor data (incurs network latency)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/waterguru/button.py
+++ b/custom_components/waterguru/button.py
@@ -1,0 +1,65 @@
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.const import STATE_ON
+from .const import DOMAIN
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    
+    entities = []
+    # Loop through your devices/pools (adapt to your existing data structure)
+    for mac, device_data in coordinator.data.items():
+        entities.append(WaterGuruResetButton(hass, coordinator, mac))
+        
+    async_add_entities(entities)
+
+
+class WaterGuruResetButton(ButtonEntity):
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    
+    def __init__(self, hass, coordinator, mac):
+        self.hass = hass
+        self.coordinator = coordinator
+        self.mac = mac
+        self._attr_unique_id = f"{mac}_replace_cassette"
+        self._attr_name = "Replace Cassette"
+
+    @property
+    def device_info(self):
+        return {"identifiers": {(DOMAIN, self.mac)}}
+
+    async def async_press(self):
+        # 1. Get current days remaining from your coordinator data
+        device_data = self.coordinator.data.get(self.mac, {})
+        days_remaining = device_data.get("cassette_days_remaining", 0)
+
+        # 2. Check the state of the override switch
+        override_switch_id = f"switch.waterguru_{self.mac.lower()}_temporarily_allow_early_cassette_replacement"
+        override_state = self.hass.states.get(override_switch_id)
+        
+        is_overridden = override_state is not None and override_state.state == STATE_ON
+
+        # 3. Validation Logic
+        if days_remaining > 0 and not is_overridden:
+            raise HomeAssistantError(
+                f"Cannot replace: {days_remaining} days remaining. "
+                "Enable the 'Temporarily Allow Early Cassette Replacement' switch to bypass."
+            )
+
+        # 4. Execute the mock API call
+        api = self.hass.data[DOMAIN]["api"]
+        await self.hass.async_add_executor_job(api.reset_cassette, self.mac)
+
+        # 5. Refresh coordinator to fetch the updated 32-day value immediately
+        await self.coordinator.async_request_refresh()
+
+        # 6. Auto-reset the override switch to Off
+        if is_overridden:
+            await self.hass.services.async_call(
+                "switch",
+                "turn_off",
+                {"entity_id": override_switch_id},
+                blocking=False
+            )

--- a/custom_components/waterguru/button.py
+++ b/custom_components/waterguru/button.py
@@ -31,7 +31,6 @@ class WaterGuruResetButton(ButtonEntity):
         return DeviceInfo(identifiers={(DOMAIN, self.device.device_id)})
 
     async def async_press(self):
-        # Extract the device object from coordinator and locate nested sensor data
         device_data = self.coordinator.data.get(self.device.device_id)
         if not device_data:
             raise HomeAssistantError("Device data not available.")
@@ -51,7 +50,7 @@ class WaterGuruResetButton(ButtonEntity):
                 "Enable the 'Temporarily Allow Early Cassette Replacement' switch to bypass."
             )
 
-        api = self.hass.data[DOMAIN]["api"]
+        api = self.coordinator.api
         await self.hass.async_add_executor_job(api.reset_cassette, self.device.device_id)
 
         await self.coordinator.async_request_refresh()

--- a/custom_components/waterguru/button.py
+++ b/custom_components/waterguru/button.py
@@ -1,5 +1,7 @@
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import entity_registry as er
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.const import STATE_ON
 from .const import DOMAIN
@@ -8,55 +10,53 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     
     entities = []
-    # Loop through your devices/pools (adapt to your existing data structure)
-    for mac, device_data in coordinator.data.items():
-        entities.append(WaterGuruResetButton(hass, coordinator, mac))
+    for device in coordinator.data.values():
+        entities.append(WaterGuruResetButton(hass, coordinator, device))
         
     async_add_entities(entities)
-
 
 class WaterGuruResetButton(ButtonEntity):
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     
-    def __init__(self, hass, coordinator, mac):
+    def __init__(self, hass, coordinator, device):
         self.hass = hass
         self.coordinator = coordinator
-        self.mac = mac
-        self._attr_unique_id = f"{mac}_replace_cassette"
+        self.device = device
+        self._attr_unique_id = f"{device.device_id}_replace_cassette"
         self._attr_name = "Replace Cassette"
 
     @property
     def device_info(self):
-        return {"identifiers": {(DOMAIN, self.mac)}}
+        return DeviceInfo(identifiers={(DOMAIN, self.device.device_id)})
 
     async def async_press(self):
-        # 1. Get current days remaining from your coordinator data
-        device_data = self.coordinator.data.get(self.mac, {})
-        days_remaining = device_data.get("cassette_days_remaining", 0)
+        # Extract the device object from coordinator and locate nested sensor data
+        device_data = self.coordinator.data.get(self.device.device_id)
+        if not device_data:
+            raise HomeAssistantError("Device data not available.")
+            
+        days_remaining = device_data.sensors.get("cassette_days_remaining", 0)
 
-        # 2. Check the state of the override switch
-        override_switch_id = f"switch.waterguru_{self.mac.lower()}_temporarily_allow_early_cassette_replacement"
-        override_state = self.hass.states.get(override_switch_id)
+        registry = er.async_get(self.hass)
+        switch_unique_id = f"{self.device.device_id}_cassette_override"
+        override_switch_id = registry.async_get_entity_id("switch", DOMAIN, switch_unique_id)
         
+        override_state = self.hass.states.get(override_switch_id) if override_switch_id else None
         is_overridden = override_state is not None and override_state.state == STATE_ON
 
-        # 3. Validation Logic
         if days_remaining > 0 and not is_overridden:
             raise HomeAssistantError(
                 f"Cannot replace: {days_remaining} days remaining. "
                 "Enable the 'Temporarily Allow Early Cassette Replacement' switch to bypass."
             )
 
-        # 4. Execute the mock API call
         api = self.hass.data[DOMAIN]["api"]
-        await self.hass.async_add_executor_job(api.reset_cassette, self.mac)
+        await self.hass.async_add_executor_job(api.reset_cassette, self.device.device_id)
 
-        # 5. Refresh coordinator to fetch the updated 32-day value immediately
         await self.coordinator.async_request_refresh()
 
-        # 6. Auto-reset the override switch to Off
-        if is_overridden:
+        if is_overridden and override_switch_id:
             await self.hass.services.async_call(
                 "switch",
                 "turn_off",

--- a/custom_components/waterguru/button.py
+++ b/custom_components/waterguru/button.py
@@ -24,7 +24,7 @@ class WaterGuruResetButton(ButtonEntity):
         self.coordinator = coordinator
         self.device = device
         self._attr_unique_id = f"{device.device_id}_replace_cassette"
-        self._attr_name = "Replace Cassette"
+        self._attr_translation_key = "replace_cassette"
 
     @property
     def device_info(self):

--- a/custom_components/waterguru/const.py
+++ b/custom_components/waterguru/const.py
@@ -3,11 +3,12 @@
 from enum import StrEnum
 
 DOMAIN = "waterguru"
+CASSETTE_ISSUE_PREFIX = "cassette_empty_"
 
 class WaterGuruEntityAttributes(StrEnum):
-  """Possible entity attributes."""
+    """Possible entity attributes."""
 
-  LAST_MEASUREMENT = "last_measurement"
-  DESC = "description"
-  STATUS_COLOR = "status_color"
-  ADVICE = "advice"
+    LAST_MEASUREMENT = "last_measurement"
+    DESC = "description"
+    STATUS_COLOR = "status_color"
+    ADVICE = "advice"

--- a/custom_components/waterguru/repairs.py
+++ b/custom_components/waterguru/repairs.py
@@ -1,0 +1,53 @@
+"""Repairs flows for the WaterGuru integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import data_entry_flow
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN, CASSETTE_ISSUE_PREFIX
+
+class CassetteEmptyRepairFlow(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the confirm step of a fix flow."""
+        if user_input is not None:
+            # Extract the device ID from the issue ID
+            device_id = self.issue_id.replace(CASSETTE_ISSUE_PREFIX, "")
+            
+            # Lookup the button's entity_id
+            registry = er.async_get(self.hass)
+            button_unique_id = f"{device_id}_replace_cassette"
+            button_entity_id = registry.async_get_entity_id("button", DOMAIN, button_unique_id)
+            
+            # Execute action: button.press
+            if button_entity_id:
+                await self.hass.services.async_call(
+                    "button", "press", {"entity_id": button_entity_id}
+                )
+
+            return self.async_create_entry(title="", data={})
+
+        return self.async_show_form(step_id="confirm", data_schema=vol.Schema({}))
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create flow."""
+    if issue_id.startswith(CASSETTE_ISSUE_PREFIX):
+        return CassetteEmptyRepairFlow()

--- a/custom_components/waterguru/switch.py
+++ b/custom_components/waterguru/switch.py
@@ -1,15 +1,15 @@
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.device_registry import DeviceInfo
 from .const import DOMAIN
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
-    # Setup logic assuming you have a coordinator managing the devices
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     
     entities = []
-    # Loop through your devices/pools (adapt to your existing data structure)
-    for mac, device_data in coordinator.data.items():
-        entities.append(WaterGuruOverrideSwitch(coordinator, mac))
+    # Loop over values() to extract the WaterGuruDevice object directly
+    for device in coordinator.data.values():
+        entities.append(WaterGuruOverrideSwitch(coordinator, device))
         
     async_add_entities(entities)
 
@@ -18,16 +18,17 @@ class WaterGuruOverrideSwitch(SwitchEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_entity_registry_enabled_default = False
     
-    def __init__(self, coordinator, mac):
+    def __init__(self, coordinator, device):
         self.coordinator = coordinator
-        self.mac = mac
-        self._attr_unique_id = f"{mac}_cassette_override"
+        self.device = device
+        self._attr_unique_id = f"{device.device_id}_cassette_override"
         self._attr_name = "Temporarily Allow Early Cassette Replacement"
         self._attr_is_on = False
 
     @property
     def device_info(self):
-        return {"identifiers": {(DOMAIN, self.mac)}}
+        # Match sensor.py DeviceInfo linkage exactly
+        return DeviceInfo(identifiers={(DOMAIN, self.device.device_id)})
 
     async def async_turn_on(self, **kwargs):
         self._attr_is_on = True

--- a/custom_components/waterguru/switch.py
+++ b/custom_components/waterguru/switch.py
@@ -1,0 +1,38 @@
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.entity import EntityCategory
+from .const import DOMAIN
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    # Setup logic assuming you have a coordinator managing the devices
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    
+    entities = []
+    # Loop through your devices/pools (adapt to your existing data structure)
+    for mac, device_data in coordinator.data.items():
+        entities.append(WaterGuruOverrideSwitch(coordinator, mac))
+        
+    async_add_entities(entities)
+
+class WaterGuruOverrideSwitch(SwitchEntity):
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+    
+    def __init__(self, coordinator, mac):
+        self.coordinator = coordinator
+        self.mac = mac
+        self._attr_unique_id = f"{mac}_cassette_override"
+        self._attr_name = "Temporarily Allow Early Cassette Replacement"
+        self._attr_is_on = False
+
+    @property
+    def device_info(self):
+        return {"identifiers": {(DOMAIN, self.mac)}}
+
+    async def async_turn_on(self, **kwargs):
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs):
+        self._attr_is_on = False
+        self.async_write_ha_state()

--- a/custom_components/waterguru/switch.py
+++ b/custom_components/waterguru/switch.py
@@ -22,7 +22,7 @@ class WaterGuruOverrideSwitch(SwitchEntity):
         self.coordinator = coordinator
         self.device = device
         self._attr_unique_id = f"{device.device_id}_cassette_override"
-        self._attr_name = "Temporarily Allow Early Cassette Replacement"
+        self._attr_translation_key = "cassette_override"
         self._attr_is_on = False
 
     @property

--- a/custom_components/waterguru/translations/en.json
+++ b/custom_components/waterguru/translations/en.json
@@ -31,5 +31,17 @@
         }
       }
     }
+  },
+  "entity": {
+    "button": {
+      "replace_cassette": {
+        "name": "Replace Cassette"
+      }
+    },
+    "switch": {
+      "cassette_override": {
+        "name": "Temporarily Allow Early Cassette Replacement"
+      }
+    }
   }
 }

--- a/custom_components/waterguru/translations/en.json
+++ b/custom_components/waterguru/translations/en.json
@@ -1,27 +1,35 @@
 {
-    "config": {
-      "flow_title": "WaterGuru",
-      "step": {
-        "user": {
-          "title": "Connect to WaterGuru",
-          "data": {
-            "username": "Username",
-            "password": "Password"
-          }
+  "config": {
+    "flow_title": "WaterGuru",
+    "step": {
+      "user": {
+        "title": "Connect to WaterGuru",
+        "data": {
+          "username": "Username",
+          "password": "Password"
         }
-      },
-      "error": {
-        "cannot_connect": "Failed to connect",
-        "unknown": "Unexpected Error"
-      },
-      "abort": {
-        "already_configured": "Account is already configured"
       }
     },
-    "issues": {
-      "cassette_empty": {
-        "title": "Replace the WaterGuru cassette",
-        "description": "The cassette for {name} has 0 days remaining. After you replace it, this repair clears automatically once WaterGuru reports days remaining again."
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "unknown": "Unexpected Error"
+    },
+    "abort": {
+      "already_configured": "Account is already configured"
+    }
+  },
+  "issues": {
+    "cassette_empty": {
+      "title": "Replace the WaterGuru cassette",
+      "description": "The cassette for {name} is empty. Replacing the cassette physically and submitting this form will reset the sensor.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Reset Cassette",
+            "description": "Confirm that you have physically replaced the cassette for {name}."
+          }
+        }
       }
     }
   }
+}

--- a/custom_components/waterguru/waterguru.py
+++ b/custom_components/waterguru/waterguru.py
@@ -23,12 +23,9 @@ class WaterGuru:
         self._username = username
         self._password = password
         self._session = session
-
-    def get(self):
-        """Get the latest data from the WaterGuru API."""
-
-        _LOGGER.info("Fetching data from WaterGuru API...")
-
+        
+    def _get_auth_and_user(self):
+        """Handle AWS Cognito authentication and return auth object and userId."""
         region_name = "us-west-2"
         pool_id = "us-west-2_icsnuWQWw"
         identity_pool_id = "us-west-2:691e3287-5776-40f2-a502-759de65a8f1c"
@@ -38,6 +35,7 @@ class WaterGuru:
         boto3.setup_default_session(region_name = region_name)
         client = boto3.client('cognito-idp', region_name=region_name)
         aws = AWSSRP(username=self._username, password=self._password, pool_id=pool_id, client_id=client_id, client=client)
+        
         try:
             tokens = aws.authenticate_user()
         except botocore.exceptions.ClientError as e:
@@ -46,8 +44,7 @@ class WaterGuru:
         id_token = tokens['AuthenticationResult']['IdToken']
         refresh_token = tokens['AuthenticationResult']['RefreshToken']
         access_token = tokens['AuthenticationResult']['AccessToken']
-        token_type = tokens['AuthenticationResult']['TokenType']
-
+        
         u=Cognito(pool_id,client_id,id_token=id_token,refresh_token=refresh_token,access_token=access_token)
         user = u.get_user()
         userId = user._metadata['username']
@@ -59,20 +56,28 @@ class WaterGuru:
 
         credentials_response = identity_client.get_credentials_for_identity(IdentityId=identity_id,Logins={idp_pool:id_token})
         credentials = credentials_response['Credentials']
-        access_key_id = credentials['AccessKeyId']
-        secret_key = credentials['SecretKey']
-        service = 'lambda'
-        session_token = credentials['SessionToken']
-        expiration = credentials['Expiration']
+        
+        auth = AWS4Auth(
+            credentials['AccessKeyId'], 
+            credentials['SecretKey'], 
+            region_name, 
+            'lambda', 
+            session_token=credentials['SessionToken']
+        )
+        
+        return auth, userId
+
+    def get(self):
+        """Get the latest data from the WaterGuru API."""
+        _LOGGER.info("Fetching data from WaterGuru API...")
+
+        auth, userId = self._get_auth_and_user()
 
         method = 'POST'
         headers = {'User-Agent': 'aws-sdk-iOS/2.24.3 iOS/14.7.1 en_US invoker', 'Content-Type': 'application/x-amz-json-1.0'}
         body = {"userId":userId, "clientType":"WEB_APP", "clientVersion":"0.2.3", "clip": False}
-        service = 'lambda'
         url = 'https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/prod-getDashboardView/invocations'
-        region = 'us-west-2'
 
-        auth = AWS4Auth(access_key_id, secret_key, region, service, session_token=session_token)
         try:
             response = requests.request(method, url, auth=auth, json=body, headers=headers, timeout=9.9)
         except requests.exceptions.Timeout as e:
@@ -80,3 +85,18 @@ class WaterGuru:
 
         data = response.json()
         return {waterBodyData['waterBodyId']: WaterGuruDevice(waterBodyData) for waterBodyData in data['waterBodies']}
+
+    def reset_cassette(self, water_body_id: str):
+        """
+        MOCK: Reset the cassette life.
+        Actual endpoint and payload to be captured on next cassette replacement.
+        """
+        _LOGGER.info("MOCK: Resetting cassette for %s", water_body_id)
+        
+        # auth, userId = self._get_auth_and_user()
+        # method = 'POST'
+        # headers = {'User-Agent': 'aws-sdk-iOS/2.24.3 iOS/14.7.1 en_US invoker', 'Content-Type': 'application/x-amz-json-1.0'}
+        # body = {"userId": userId, "waterBodyId": water_body_id, ...}
+        # url = 'https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/prod-replaceCassette/invocations'
+        
+        return True

--- a/custom_components/waterguru/waterguru.py
+++ b/custom_components/waterguru/waterguru.py
@@ -45,7 +45,7 @@ class WaterGuru:
         refresh_token = tokens['AuthenticationResult']['RefreshToken']
         access_token = tokens['AuthenticationResult']['AccessToken']
         
-        u=Cognito(pool_id,client_id,id_token=id_token,refresh_token=refresh_token,access_token=access_token)
+        u = Cognito(pool_id, client_id, id_token=id_token, refresh_token=refresh_token, access_token=access_token)
         user = u.get_user()
         userId = user._metadata['username']
 
@@ -54,7 +54,7 @@ class WaterGuru:
         identity_response = identity_client.get_id(IdentityPoolId=identity_pool_id)
         identity_id = identity_response['IdentityId']
 
-        credentials_response = identity_client.get_credentials_for_identity(IdentityId=identity_id,Logins={idp_pool:id_token})
+        credentials_response = identity_client.get_credentials_for_identity(IdentityId=identity_id, Logins={idp_pool:id_token})
         credentials = credentials_response['Credentials']
         
         auth = AWS4Auth(
@@ -75,7 +75,7 @@ class WaterGuru:
 
         method = 'POST'
         headers = {'User-Agent': 'aws-sdk-iOS/2.24.3 iOS/14.7.1 en_US invoker', 'Content-Type': 'application/x-amz-json-1.0'}
-        body = {"userId":userId, "clientType":"WEB_APP", "clientVersion":"0.2.3", "clip": False}
+        body = {"userId": userId, "clientType": "WEB_APP", "clientVersion": "0.2.3", "clip": False}
         url = 'https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/prod-getDashboardView/invocations'
 
         try:
@@ -86,17 +86,29 @@ class WaterGuru:
         data = response.json()
         return {waterBodyData['waterBodyId']: WaterGuruDevice(waterBodyData) for waterBodyData in data['waterBodies']}
 
-    def reset_cassette(self, water_body_id: str):
-        """
-        MOCK: Reset the cassette life.
-        Actual endpoint and payload to be captured on next cassette replacement.
-        """
-        _LOGGER.info("MOCK: Resetting cassette for %s", water_body_id)
-        
-        # auth, userId = self._get_auth_and_user()
-        # method = 'POST'
-        # headers = {'User-Agent': 'aws-sdk-iOS/2.24.3 iOS/14.7.1 en_US invoker', 'Content-Type': 'application/x-amz-json-1.0'}
-        # body = {"userId": userId, "waterBodyId": water_body_id, ...}
-        # url = 'https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/prod-replaceCassette/invocations'
-        
-        return True
+    def reset_cassette(self, pod_id: str) -> None:
+        """Reset the cassette percentage to 100% via AWS Lambda invocation."""
+        _LOGGER.info("Resetting cassette on WaterGuru pod %s...", pod_id)
+
+        auth, userId = self._get_auth_and_user()
+
+        method = 'POST'
+        headers = {'User-Agent': 'aws-sdk-iOS/2.24.3 iOS/14.7.1 en_US invoker', 'Content-Type': 'application/x-amz-json-1.0'}
+        url = 'https://lambda.us-west-2.amazonaws.com/2015-03-31/functions/prod-managePod/invocations'
+        body = {
+            "podId": int(pod_id),
+            "refillableReq": {
+                "padPctLeft": 100
+            },
+            "clientType": "WEB_APP",
+            "clientVersion": "0.2.3",
+            "reqUserId": userId,
+        }
+
+        try:
+            response = requests.request(method, url, auth=auth, json=body, headers=headers, timeout=9.9)
+        except requests.exceptions.Timeout as e:
+            raise WaterGuruApiError("Timeout while accessing WaterGuru API") from e
+
+        if response.status_code not in (200, 202):
+            raise WaterGuruApiError(f"Failed to reset cassette: {response.status_code} - {response.text}")


### PR DESCRIPTION
Currently, the integration lacks a native method to reset the cassette life from within Home Assistant, requiring users to open the mobile app when replacing a cassette.

Proposed Changes
- API Updates (waterguru.py): Added a reset_cassette method that issues a POST request to the AWS Lambda prod-managePod endpoint, passing the pod_id and setting padPctLeft to 100. Refactored the AWS Cognito authentication into a reusable _get_auth_and_user helper method.
- New Entities (button.py, switch.py): Added a WaterGuruResetButton entity to trigger the API call. Added a WaterGuruOverrideSwitch ("Temporarily Allow Early Cassette Replacement") to act as a safety lockout. The button verifies the cassette is empty or the override switch is active before executing, and immediately turns off the override switch afterward.
- Repair Flow (repairs.py, __init__.py): Updated the cassette repair logic to evaluate the percentage remaining (pct_remaining) instead of a text string, as the days remaining property is not consistently populated by the API during a reset. Configured the repair issue to be fixable, introducing a CassetteEmptyRepairFlow that automatically calls the button press service upon user confirmation.
- Translations (en.json): Added the necessary UI text for the new entities and repair flow dialogs. 